### PR TITLE
marqeta-user-list-transitions-fields: fixed listTransitions() empty f…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,9 +98,10 @@ export class Marqeta {
     // build up the complete url from the provided 'uri' and the 'host'
     let url = new URL(PROTOCOL+'://'+path.join(this.host, uri))
     if (query) {
-      Object.keys(query).forEach(k => {
-        if (something(query[k])) {
-          url.searchParams.append(k, query[k].toString())
+      const cleanQuery = removeEmpty(query)
+      Object.keys(cleanQuery).forEach(k => {
+        if (something(cleanQuery[k])) {
+          url.searchParams.append(k, cleanQuery[k].toString())
         }
       })
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,10 +98,9 @@ export class Marqeta {
     // build up the complete url from the provided 'uri' and the 'host'
     let url = new URL(PROTOCOL+'://'+path.join(this.host, uri))
     if (query) {
-      const cleanQuery = removeEmpty(query)
-      Object.keys(cleanQuery).forEach(k => {
-        if (something(cleanQuery[k])) {
-          url.searchParams.append(k, cleanQuery[k].toString())
+      Object.keys(query).forEach(k => {
+        if (something(query[k])) {
+          url.searchParams.append(k, query[k].toString())
         }
       })
     }
@@ -147,7 +146,7 @@ export class Marqeta {
  * trying to place them on the call.
  */
 function something(arg: any) {
-  return arg || arg === false || arg === 0 || arg === ''
+  return arg || arg === false || arg === 0
 }
 
 /*

--- a/src/user.ts
+++ b/src/user.ts
@@ -266,16 +266,48 @@ export class UserApi {
   }
 
   /*
-   * Function to take a User token Id, send that to Marqeta, and have a list of
-   * User transition statuses returned.
+   * Function to take a list of search parameters, send those to Marqeta, and
+   * have a list of User transition statuses returned for a User, where
+   * "token" correlates to a Marqeta User account, "count" determines
+   * how many business transitions to return, "startIndex" is the sort order
+   * index of the first resource in the response, "fields" determines  which
+   * Transition fields to include in the response (leaving this empty returns
+   * all Transition fields for a User Transition), and "sortBy" is the
+   * Transition field by which to sort the response, e.g. lastModifiedData,
+   * createdTime, etc.
    */
-  async listTransition(token: string): Promise<{
+  async listTransition(search: {
+    token?: string,
+    count?: number,
+    startIndex?: number,
+    fields?: string[],
+    sortBy?: string,
+  } = {}): Promise<{
     success: boolean,
     body?: TransitionList,
     error?: MarqetaError,
   }> {
+    const {
+      token = '',
+      count = 100,
+      startIndex = 0,
+      fields = '',
+      sortBy = 'lastModifiedTime',
+    } = search
+    if (!token) {
+      return {
+        success: true, body: {
+          count: BigInt(0),
+          startIndex: BigInt(0),
+          endIndex: BigInt(0),
+          isMore: false,
+          data: [],
+        }
+      }
+    }
     const resp = await this.client.fire('GET',
-      `usertransitions/user/${token}`,
+      `/usertransitions/user/${token}`,
+      { count, startIndex, fields, sortBy },
     )
     // catch any errors...
     if (resp?.payload?.errorCode) {
@@ -290,5 +322,4 @@ export class UserApi {
     }
     return { success: !resp?.payload?.errorCode, body: { ...resp.payload } }
   }
-
 }

--- a/src/user.ts
+++ b/src/user.ts
@@ -306,7 +306,7 @@ export class UserApi {
       }
     }
     const resp = await this.client.fire('GET',
-      `/usertransitions/user/${token}`,
+      `usertransitions/user/${token}`,
       { count, startIndex, fields, sortBy },
     )
     // catch any errors...

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -43,6 +43,7 @@ import { Marqeta } from '../src'
 
         if (foundUserA.body.firstName) {
           foundUserA.body.firstName += Math.floor(Math.random() * 100) + 1
+          foundUserA.body.firstName = foundUserA.body.firstName.slice(0, 20)
           upUserA = await client.user.update(foundUserA.body)
         }
 
@@ -109,7 +110,6 @@ import { Marqeta } from '../src'
     console.log('Error! Unable to create the User account')
     console.log(mockUser)
   }
-
   console.log('testing User search...')
   const { email, ...searchFields } = mockUser // eslint-disable-line
   const userExists = await client.user.search(searchFields)
@@ -170,7 +170,7 @@ import { Marqeta } from '../src'
   console.log('testing list User transitions by User token Id...')
   if (testUser?.token) {
     let listTrans
-    listTrans = await client.user.listTransition(testUser?.token)
+    listTrans = await client.user.listTransition({ ...testUser })
 
     if (listTrans?.success && listTrans?.body?.count) {
       console.log('Success! We were able to get a list of User transitions.')
@@ -182,6 +182,29 @@ import { Marqeta } from '../src'
     console.log('Error! Unable to get User transition because the User ' +
       'token is empty.')
     console.log(listA)
+  }
+
+  console.log('testing list one User transitions by token Id...')
+  if (testUser?.token) {
+    let listTransOne
+    listTransOne = await client.user.listTransition({
+      ...testUser,
+      count: 1,
+    })
+    if (listTransOne?.success
+      && listTransOne?.body?.count && listTransOne.body) {
+      console.log(`[ONE: ] ${JSON.stringify(listTransOne)}`)
+      console.log('Success! We were able to get a list of one User ' +
+        'transitions.')
+    } else {
+      console.log('Error! We were unable to get a list of one User ' +
+        'transitions.')
+      console.log(listTransOne)
+    }
+  } else {
+    console.log('Error! Unable to get list of User transition statuses ' +
+      'because the User token Id is empty.')
+    console.log(testUser)
   }
 
 })()

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -193,9 +193,7 @@ import { Marqeta } from '../src'
     })
     if (listTransOne?.success
       && listTransOne?.body?.count && listTransOne.body) {
-      console.log(`[ONE: ] ${JSON.stringify(listTransOne)}`)
-      console.log('Success! We were able to get a list of one User ' +
-        'transitions.')
+      console.log('Success! We were able to get a list of one User transitions.')
     } else {
       console.log('Error! We were unable to get a list of one User ' +
         'transitions.')


### PR DESCRIPTION
…ields param

Pull request to address the behaviour of the Marqeta `/usertransitions/user/${token}`  endpoint, which is that the Search query parameter `fields` cannot be empty. 