### PR TITLE
marqeta-authorization-merchant-byTokenId-fix: return type was incorrect

### DIFF
--- a/src/authorization-control.ts
+++ b/src/authorization-control.ts
@@ -217,7 +217,7 @@ export class AuthorizationControlApi {
    */
   async getMerchantExemption(token?: string): Promise<{
     success: boolean,
-    body?: AuthorizationControl,
+    body?: Merchant,
     error?: MarqetaError,
   }> {
     const resp = await this.client.fire('GET',


### PR DESCRIPTION
The  `getMerchantExemption()` function was returning type `AuthorizationControl` and needed to return type `Merchnat.` The PR fixes that.