### PR TITLE
marqeta-commando-mode-get: commando mode module with list() function

### DIFF
--- a/src/commando-mode.ts
+++ b/src/commando-mode.ts
@@ -1,0 +1,69 @@
+'use strict'
+
+import type {
+  Marqeta, MarqetaError,
+  MarqetaOptions,
+} from './'
+
+export interface CommandoMode {
+  token: string;
+  programGatewayFundingSourceToken: string;
+  currentState: {
+    commandoEnabled: boolean;
+    reason: string;
+    channel: string;
+  };
+  commandoModeEnables: {
+    programFundingSource: string;
+    velocityControls: string[];
+  };
+  createdTime: string;
+  lastModifiedTime: string;
+}
+
+export interface CommandoModeList {
+  count: 1;
+  startIndex: 0;
+  endIndex: 0;
+  isMore: false;
+  data: CommandoMode[];
+}
+
+export class CommandoModeApi {
+  client: Marqeta;
+
+  constructor(client: Marqeta, _options?: MarqetaOptions) {
+    this.client = client
+  }
+
+  /*
+   * Function to take a list of optional Commando Mode arguments, send those to
+   * Marqeta, and have a list of Commando Modes returned to the caller.
+   */
+  async list(options: {
+    count?: number,
+    startIndex?: number,
+    sortBy?: string,
+  } = {}): Promise<{
+    success: boolean,
+    commandoModes?: CommandoModeList,
+    error?: MarqetaError,
+  }> {
+    const resp = await this.client.fire('GET',
+      'commandomodes',
+      options
+    )
+    // catch any errors...
+    if (resp?.payload?.errorCode) {
+      return {
+        success: false,
+        error: {
+          type: 'marqeta',
+          error: resp?.payload?.errorMessage,
+          status: resp?.payload?.errorCode,
+        },
+      }
+    }
+    return { success: !resp?.payload?.errorCode, commandoModes: { ...resp.payload } }
+  }
+}

--- a/src/commando-mode.ts
+++ b/src/commando-mode.ts
@@ -1,7 +1,8 @@
 'use strict'
 
 import type {
-  Marqeta, MarqetaError,
+  Marqeta,
+  MarqetaError,
   MarqetaOptions,
 } from './'
 
@@ -22,10 +23,10 @@ export interface CommandoMode {
 }
 
 export interface CommandoModeList {
-  count: 1;
-  startIndex: 0;
-  endIndex: 0;
-  isMore: false;
+  count: bigint;
+  startIndex: bigint;
+  endIndex: bigint;
+  isMore: boolean;
   data: CommandoMode[];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import { VelocityControlApi } from './velocity-control'
 import { AuthorizationControlApi } from './authorization-control'
 import { MerchantGroupApi } from './merchant-group'
 import { MccGroupApi } from './mcc-group'
+import { CommandoModeApi } from './commando-mode'
 
 const PROTOCOL = 'https'
 const MARQETA_HOST = 'sandbox-api.marqeta.com/v3'
@@ -82,6 +83,7 @@ export class Marqeta {
   authorizationControl: AuthorizationControlApi
   merchantGroup: MerchantGroupApi
   mccGroup: MccGroupApi
+  commandoMode: CommandoModeApi
 
   constructor (options?: MarqetaOptions) {
     this.host = options?.host || MARQETA_HOST
@@ -102,6 +104,7 @@ export class Marqeta {
     this.authorizationControl = new AuthorizationControlApi(this, options)
     this.merchantGroup = new MerchantGroupApi(this, options)
     this.mccGroup = new MccGroupApi(this, options)
+    this.commandoMode = new CommandoModeApi(this, options)
   }
 
   /*

--- a/tests/commando-mode.test.ts
+++ b/tests/commando-mode.test.ts
@@ -14,7 +14,6 @@ import { Marqeta } from '../src';
 
   if (modes?.success) {
     console.log('Success! A list of Commando Modes was retrieved.')
-    console.log(JSON.stringify(modes))
   } else {
     console.log('Error! Unable to get a list of Commando Modes.')
     console.log(modes)

--- a/tests/commando-mode.test.ts
+++ b/tests/commando-mode.test.ts
@@ -1,0 +1,23 @@
+'use strict'
+
+import { Marqeta } from '../src';
+(async () => {
+
+  const client = new Marqeta({
+    host: process.env.MARQETA_HOST,
+    apiAppToken: process.env.MARQETA_API_APP_TOKEN,
+    apiAccessToken: process.env.MARQETA_API_ACCESS_TOKEN
+  })
+
+  console.log('getting Marqeta Card Products...')
+  const modes = await client.cardProduct.list()
+
+  if (modes?.success) {
+    console.log('Success! A list of Commando Modes was retrieved.')
+    console.log(JSON.stringify(modes))
+  } else {
+    console.log('Error! Unable to get a list of Commando Modes.')
+    console.log(modes)
+  }
+
+})()


### PR DESCRIPTION
Pull Request for the `Commando Mode` module with a` list()` function.  Commando Mode is a fallback measure that ensures `Gateway` JIT-funded cards continue to function in the event that your system fails.