### PR TITLE
marqeta-fundingach-stub

### DIFF
--- a/src/funding-ach.ts
+++ b/src/funding-ach.ts
@@ -1,0 +1,26 @@
+'use strict'
+
+import type {
+  Marqeta,
+  MarqetaOptions,
+} from './'
+
+export interface FundingAch {
+  token: string;
+  userToken: string;
+  routingNumber: string;
+  nameOnAccount: string;
+  isDefaultAccount: boolean;
+  accountNumber: string;
+  accountType: string;
+  verificationNotes: string;
+  verificationOverride: boolean;
+}
+
+export class FundingAchApi {
+  client: Marqeta;
+
+  constructor(client: Marqeta, _options?: MarqetaOptions) {
+    this.client = client
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import { AuthorizationControlApi } from './authorization-control'
 import { MerchantGroupApi } from './merchant-group'
 import { MccGroupApi } from './mcc-group'
 import { FundingProgramApi } from './funding-program'
+import { FundingAchApi } from './funding-ach'
 
 const PROTOCOL = 'https'
 const MARQETA_HOST = 'sandbox-api.marqeta.com/v3'
@@ -84,6 +85,7 @@ export class Marqeta {
   merchantGroup: MerchantGroupApi
   mccGroup: MccGroupApi
   fundingProgram: FundingProgramApi
+  funcingAch: FundingAchApi
 
   constructor (options?: MarqetaOptions) {
     this.host = options?.host || MARQETA_HOST
@@ -105,6 +107,7 @@ export class Marqeta {
     this.merchantGroup = new MerchantGroupApi(this, options)
     this.mccGroup = new MccGroupApi(this, options)
     this.fundingProgram = new FundingProgramApi(this, options)
+    this.fundingAch = new FundingAchApi(this, options)
   }
 
   /*


### PR DESCRIPTION
Pull request to stub out the `Funding ACH` module so users can extend the `FundingAchApi` class if implementing a Card program other than the `JIT Gateway Funding` model that this client supports.