### PR TITLE
marqeta-autoreload-stub

### DIFF
--- a/src/auto-reload.ts
+++ b/src/auto-reload.ts
@@ -1,0 +1,29 @@
+'use strict'
+
+import { Marqeta, MarqetaOptions } from './index'
+
+export interface autoReload {
+  token: string;
+  active: boolean;
+  currencyCode: string;
+  association: {
+    userToken: string;
+  };
+  fundingSourceToken: string;
+  orderScope: {
+    gpa: {
+      triggerAmount: number;
+      reloadAmount: number;
+    };
+  };
+  createdTime: string;
+  lastModifiedTime: string;
+}
+
+export class AutoReloadApi {
+  client: Marqeta;
+
+  constructor(client: Marqeta, _options?: MarqetaOptions) {
+    this.client = client
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { MerchantGroupApi } from './merchant-group'
 import { MccGroupApi } from './mcc-group'
 import { FundingProgramApi } from './funding-program'
 import { FundingAchApi } from './funding-ach'
+import { AutoReloadApi } from './auto-reload'
 
 const PROTOCOL = 'https'
 const MARQETA_HOST = 'sandbox-api.marqeta.com/v3'
@@ -85,7 +86,8 @@ export class Marqeta {
   merchantGroup: MerchantGroupApi
   mccGroup: MccGroupApi
   fundingProgram: FundingProgramApi
-  funcingAch: FundingAchApi
+  fundingAch: FundingAchApi
+  autoReload: AutoReloadApi
 
   constructor (options?: MarqetaOptions) {
     this.host = options?.host || MARQETA_HOST
@@ -108,6 +110,7 @@ export class Marqeta {
     this.mccGroup = new MccGroupApi(this, options)
     this.fundingProgram = new FundingProgramApi(this, options)
     this.fundingAch = new FundingAchApi(this, options)
+    this.autoReload = new AutoReloadApi(this, options)
   }
 
   /*


### PR DESCRIPTION
Pull request to stub out the` auto-reload` api module so that users can extend the `AutoReloadApi` class if they are using a Program or ACH funding source, versus a `Gateway JIT funding` model. 