### PR TITLE
marqeta-program-reserve-stub

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { FundingProgramApi } from './funding-program'
 import { FundingAchApi } from './funding-ach'
 import { AutoReloadApi } from './auto-reload'
 import { BalancesApi } from './balances'
+import { ProgramReserveApi } from './program-reserve'
 
 const PROTOCOL = 'https'
 const MARQETA_HOST = 'sandbox-api.marqeta.com/v3'
@@ -90,6 +91,7 @@ export class Marqeta {
   fundingAch: FundingAchApi
   autoReload: AutoReloadApi
   balances: BalancesApi
+  programReserve: ProgramReserveApi
 
   constructor (options?: MarqetaOptions) {
     this.host = options?.host || MARQETA_HOST
@@ -114,6 +116,7 @@ export class Marqeta {
     this.fundingAch = new FundingAchApi(this, options)
     this.autoReload = new AutoReloadApi(this, options)
     this.balances = new BalancesApi(this, options)
+    this.programReserve = new ProgramReserveApi(this, options)
   }
 
   /*

--- a/src/program-reserve.ts
+++ b/src/program-reserve.ts
@@ -1,0 +1,11 @@
+'use strict'
+
+import { Marqeta, MarqetaOptions } from './index'
+
+export class ProgramReserveApi {
+  client: Marqeta;
+
+  constructor(client: Marqeta, _options?: MarqetaOptions) {
+    this.client = client
+  }
+}


### PR DESCRIPTION
Pull request to stub out the Program Reserve module so users can extend the ProgramReserveApi when implementing a `Program` or `ACH` funded card program. 