### PR TITLE
marqeta-card-pin-createtoken-fix: semantics - changed name of create(…

### DIFF
--- a/src/card-pin.ts
+++ b/src/card-pin.ts
@@ -16,9 +16,10 @@ export class CardPinApi {
 
   /*
    * Function to take a Card token Id, an optional Control Token type, send
-   * those to Marqeta, and have them create and return a Card PIN.
+   * those to Marqeta, and have them create and return a Control Token which is
+   * required when creating or updating a Card PIN.
    */
-  async create(card: Partial<CardPin>): Promise<{
+  async createControlToken(cardPin: Partial<CardPin>): Promise<{
     success: boolean,
     cardPin?: CardPin,
     error?: MarqetaError,
@@ -26,7 +27,7 @@ export class CardPinApi {
     const resp = await this.client.fire('POST',
       'pins/controltoken',
       undefined,
-      card,
+      cardPin,
     )
     // catch any errors...
     if (resp?.payload?.errorCode) {

--- a/tests/card-pin.test.ts
+++ b/tests/card-pin.test.ts
@@ -14,7 +14,10 @@ import { Marqeta } from '../src';
 
   const mockPin = {
     cardToken: '',
+    cardTokenType: '',
+    pin: '',
   }
+
   console.log('getting a list of users...')
 
   let newCard, user
@@ -29,6 +32,7 @@ import { Marqeta } from '../src';
       && Array.isArray(products?.cardProducts?.data)) {
       const product = products?.cardProducts?.data.pop()
 
+      console.log('creating new card PIN...')
       if (user?.token && product?.token) {
         console.log('creating a new Card...')
         mockCard.userToken = user.token


### PR DESCRIPTION
…) function

This pull request is a semantic change the name of the` create()` function to `createControlToken()` so that it is not confused with the upcoming ` createUpdate()` function.