### PR TITLE
marqeta-user-transition-fix:

### DIFF
--- a/src/user-transition.ts
+++ b/src/user-transition.ts
@@ -35,7 +35,7 @@ export class UserTransitionApi {
    * Function to a User token, status, reason code, and channel, send
    * those to Marqeta, and transition a User account between states.
    */
-  async transition(status: Partial<Transition>): Promise<{
+  async create(status: Partial<Transition>): Promise<{
     success: boolean,
     transition?: Transition,
     error?: MarqetaError,
@@ -63,7 +63,7 @@ export class UserTransitionApi {
    * Function to take a Transition token Id, send that to Marqeta, and have the
    * transition status information returned.
    */
-  async getTransition(token: string): Promise<{
+  async byTokenId(token: string): Promise<{
     success: boolean,
     transition?: Transition,
     error?: MarqetaError,
@@ -96,7 +96,7 @@ export class UserTransitionApi {
    * Transition field by which to sort the response, e.g. lastModifiedData,
    * createdTime, etc.
    */
-  async listTransition(search: {
+  async list(search: {
     token?: string,
     count?: number,
     startIndex?: number,

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -9,7 +9,7 @@ import { Marqeta } from '../src'
     apiAccessToken: process.env.MARQETA_API_ACCESS_TOKEN
   })
 
-  const emailNum = Math.floor(Math.random() * 50) + 1
+  const emailNum = Math.floor(Math.random() * 100) + 1
   const mockUser = {
     token: '',
     firstName: 'Ipsumi4',
@@ -135,7 +135,7 @@ import { Marqeta } from '../src'
         channel: 'API',
         userToken: testUser.token,
       }
-      trans = await client.userTransition.transition(state)
+      trans = await client.userTransition.create(state)
 
       if (trans?.transition?.token) {
         console.log('Success! The User was transitioned to status: "' +
@@ -153,7 +153,7 @@ import { Marqeta } from '../src'
   console.log('testing get User transition by token Id...')
   if (trans?.transition?.token) {
     let getTrans
-    getTrans = await client.userTransition.getTransition(trans?.transition?.token)
+    getTrans = await client.userTransition.byTokenId(trans?.transition?.token)
 
     if (getTrans?.transition?.token) {
       console.log('Success! We were able to get the Transition status.')
@@ -170,7 +170,7 @@ import { Marqeta } from '../src'
   console.log('testing list User transitions by User token Id...')
   if (testUser?.token) {
     let listTrans
-    listTrans = await client.userTransition.listTransition({ ...testUser })
+    listTrans = await client.userTransition.list({ ...testUser })
 
     if (listTrans?.success && listTrans?.transitionList?.count) {
       console.log('Success! We were able to get a list of User transitions.')
@@ -187,7 +187,7 @@ import { Marqeta } from '../src'
   console.log('testing list one User transitions by token Id...')
   if (testUser?.token) {
     let listTransOne
-    listTransOne = await client.userTransition.listTransition({
+    listTransOne = await client.userTransition.list({
       ...testUser,
       count: 1,
     })


### PR DESCRIPTION
This pull request is for the `user-transition.ts` module where the functions were renamed to match the naming conventions of the other transitions module functions.  This was done so users of this client do not get confused and can expect all the transition modules to have a `create()`, `byTokenId()` and `list()` functions. 