### PR TITLE
marqeta-accountholder-groups-fix-interface: renamed interface

### DIFF
--- a/src/account-holder-groups.ts
+++ b/src/account-holder-groups.ts
@@ -5,7 +5,7 @@ import type {
   MarqetaOptions,
 } from './'
 
-export interface FundingProgram {
+export interface AccountHolderGroups {
   token?: string;
   name?: string;
   config?: {


### PR DESCRIPTION
Pull request to change correct the `AccountHolderGroups` interface name. 