### PR TITLE
marqeta-funding-address-stub

### DIFF
--- a/src/funding-address.ts
+++ b/src/funding-address.ts
@@ -1,0 +1,32 @@
+'use strict'
+
+import type {
+  Marqeta,
+  MarqetaOptions,
+} from './'
+
+export interface FundingAddress {
+  userToken?:	string;
+  businessToken?:	string;
+  token?: string;
+  firstName:	string;
+  lastName:	string;
+  address1:	string;
+  address2?:	string;
+  city:	string;
+  state:	string;
+  zip?:	string;
+  country:	string;
+  phone?:	string;
+  isDefaultAddress?:	boolean;
+  active?:	boolean;
+  postalCode?: string;
+}
+
+export class FundingAddressApi {
+  client: Marqeta;
+
+  constructor(client: Marqeta, _options?: MarqetaOptions) {
+    this.client = client
+  }
+}

--- a/src/funding-address.ts
+++ b/src/funding-address.ts
@@ -1,25 +1,23 @@
-'use strict'
-
 import type {
   Marqeta,
   MarqetaOptions,
 } from './'
 
 export interface FundingAddress {
-  userToken?:	string;
-  businessToken?:	string;
+  userToken?: string;
+  businessToken?: string;
   token?: string;
-  firstName:	string;
-  lastName:	string;
-  address1:	string;
-  address2?:	string;
-  city:	string;
-  state:	string;
-  zip?:	string;
-  country:	string;
-  phone?:	string;
-  isDefaultAddress?:	boolean;
-  active?:	boolean;
+  firstName: string;
+  lastName: string;
+  address1: string;
+  address2?: string;
+  city: string;
+  state: string;
+  zip?: string;
+  country: string;
+  phone?: string;
+  isDefaultAddress?: boolean;
+  active?: boolean;
   postalCode?: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { CardPinApi } from './card-pin'
 import { UserTransitionApi } from './user-transition'
 import { BusinessTransitionApi } from './business-transition'
 import { AccountHolderGroupsApi } from './account-holder-groups'
+import { FundingAddressApi } from './funding-address'
 
 const PROTOCOL = 'https'
 const MARQETA_HOST = 'sandbox-api.marqeta.com/v3'
@@ -102,6 +103,7 @@ export class Marqeta {
   userTransition: UserTransitionApi
   businessTransition: BusinessTransitionApi
   accountHolderGroups: AccountHolderGroupsApi
+  fundingAddress: FundingAddressApi
 
   constructor (options?: MarqetaOptions) {
     this.host = options?.host || MARQETA_HOST
@@ -132,6 +134,7 @@ export class Marqeta {
     this.userTransition = new UserTransitionApi(this, options)
     this.businessTransition = new BusinessTransitionApi(this, options)
     this.accountHolderGroups = new AccountHolderGroupsApi(this, options)
+    this.fundingAddress = new FundingAddressApi(this, options)
   }
 
   /*


### PR DESCRIPTION
Pull request for the Marqeta client Funding Address module stub implementation.  This base module will allow users to extend the `FundingAddressApi` class if they need to send the Funding Address api requests.