### PR TITLE
marqeta-gpa-order-stub

### DIFF
--- a/src/gpa-order.ts
+++ b/src/gpa-order.ts
@@ -1,0 +1,25 @@
+import type {
+  Marqeta,
+  MarqetaOptions,
+} from './'
+
+export interface GpaOrder {
+  tags?: string;
+  memo?: string;
+  fees?: string[];
+  token?: string;
+  userToken?: string;
+  businessToken?: string;
+  amount: number;
+  currencyCode: string;
+  fundingSourceToken: string;
+  fundingSourceAddressToken?: string;
+}
+
+export class GpaOrderApi {
+  client: Marqeta;
+
+  constructor(client: Marqeta, _options?: MarqetaOptions) {
+    this.client = client
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import { BusinessTransitionApi } from './business-transition'
 import { AccountHolderGroupsApi } from './account-holder-groups'
 import { FundingAddressApi } from './funding-address'
 import { AcceptedCountriesApi } from './accepted-countries'
+import { GpaOrderApi } from './gpa-order'
 
 const PROTOCOL = 'https'
 const MARQETA_HOST = 'sandbox-api.marqeta.com/v3'
@@ -106,6 +107,7 @@ export class Marqeta {
   accountHolderGroups: AccountHolderGroupsApi
   fundingAddress: FundingAddressApi
   acceptedCountries: AcceptedCountriesApi
+  gpaOrder: GpaOrderApi
 
   constructor (options?: MarqetaOptions) {
     this.host = options?.host || MARQETA_HOST
@@ -138,6 +140,7 @@ export class Marqeta {
     this.accountHolderGroups = new AccountHolderGroupsApi(this, options)
     this.fundingAddress = new FundingAddressApi(this, options)
     this.acceptedCountries = new AcceptedCountriesApi(this, options)
+    this.gpaOrder = new GpaOrderApi(this, options)
   }
 
   /*


### PR DESCRIPTION
Pull request for the GPA Orders module stub.  Users can extend the `GpaOrdersApi` class if needed.