### PR TITLE
marqeta-user-retrieve

### DIFF
--- a/src/user.ts
+++ b/src/user.ts
@@ -6,24 +6,6 @@ import type {
   MarqetaError,
 } from './'
 
-export interface Transition {
-  idempotentHash?: string;
-  token?: string;
-  status: string;
-  reasonCode: string;
-  reason?: string;
-  channel: string;
-  userToken: string;
-}
-
-export interface TransitionList {
-  count: bigint;
-  startIndex: bigint;
-  endIndex: bigint;
-  isMore: boolean;
-  data?: Transition[];
-}
-
 export interface UserIdentification {
   type: string;
   value: string;
@@ -103,7 +85,7 @@ export class UserApi {
    * Function to take a token Id and return the Marqeta User account associated
    * with that token Id.
    */
-  async byTokenId(userTokenId: string): Promise<{
+  async retrieve(userTokenId: string): Promise<{
     success: boolean,
     user?: User,
     error?: MarqetaError,

--- a/tests/user.test.ts
+++ b/tests/user.test.ts
@@ -33,8 +33,8 @@ import { Marqeta } from '../src'
     testUser = listA.userList.data.pop()
 
     if (testUser?.token) {
-      console.log('getting User by token Id...')
-      foundUserA = await client.user.byTokenId(testUser.token)
+      console.log('retrieving User by token Id...')
+      foundUserA = await client.user.retrieve(testUser.token)
 
       if (foundUserA?.user?.token) {
         console.log('Success! Marqeta User found by token id: ' +


### PR DESCRIPTION
This pull requests changes the User module `byTokenId()` to `retrieve()` to match the Marqeta documentation.  Additionally, the Transition and TransitionList interfaces were removed from the `user.ts` module as they were moved to the `user-transition.ts` module.   