### PR TITLE
marqeta-readme-business-transition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1540,6 +1540,117 @@ and the response will look something like this:
 }
 ```
 
+### Business Account Transition Calls
+[documentation](https://www.marqeta.com/docs/core-api/business-transitions)
+
+> Use the /businesstransitions endpoints to transition business resources 
+> between states, and to retrieve and list state changes for a business 
+> resource.
+
+#### [Create Business Account Transition](https://www.marqeta.com/docs/core-api/business-transitions#postBusinesstransitions)
+
+To transition a Business accounts status, use this call:
+
+```typescript
+const resp = await client.businessTransition.create({
+  status: 'ACTIVE',
+  reasonCode: '02',
+  channel: 'API',
+  businessToken: listItem.token,
+})
+```
+
+and the response will look something like this:
+
+```javascript
+{
+  "success": true,
+  "transition": {
+    "token": "124ccc74-b4ef-43b7-af77-dfde687a14d7",
+    "status": "ACTIVE",
+    "reasonCode": "02",
+    "channel": "API",
+    "createdTime": "2022-06-02T20:44:26Z",
+    "lastModifiedTime": "2022-06-02T20:44:26Z",
+    "businessToken": "c1e98151-d230-48b3-b063-d8be437c1d60"
+  }
+}
+```
+
+#### [Retrieve Business Account Transition](https://www.marqeta.com/docs/core-api/business-transitions#getBusinesstransitionsToken)
+
+To retrieve a Business account transition by token Id, this call can be used:
+
+```typescript
+const resp = await client.businessTransition.retrieve(
+  '124ccc74-b4ef-43b7-af77-dfde687a14d7'
+)
+```
+and the response will look something like this:
+
+```javascript
+{
+  "success": true,
+  "transition": {
+    "token": "124ccc74-b4ef-43b7-af77-dfde687a14d7",
+    "status": "ACTIVE",
+    "reasonCode": "02",
+    "channel": "API",
+    "createdTime": "2022-06-02T20:44:26Z",
+    "lastModifiedTime": "2022-06-02T20:44:26Z",
+    "businessToken": "c1e98151-d230-48b3-b063-d8be437c1d60"
+  }
+}
+```
+#### [List Business Account Transitions](https://www.marqeta.com/docs/core-api/business-transitions#getBusinesstransitionsBusinessBusinesstoken)
+
+And finally, to get a list of Business Account transitions, use this call 
+with a Business token Id, and or optional filter fields: count, sortBy, 
+etc.
+
+```typescript
+const resp = await client.businessTransition.list({
+  '24ccc74-b4ef-43b7-af77-dfde687a14d7',
+  count: 2,
+  sortBy: 'lastModifiedTime',
+})
+```
+
+and the list response will look something like this:
+
+```javascript
+{
+  "success": true,
+  "transitions": {
+    "count": 2,
+    "startIndex": 0,
+    "endIndex": 1,
+    "isMore": false,
+    "data": [
+      {
+        "token": "124ccc74-b4ef-43b7-af77-dfde687a14d7",
+        "status": "ACTIVE",
+        "reasonCode": "02",
+        "channel": "API",
+        "createdTime": "2022-06-02T20:44:26Z",
+        "lastModifiedTime": "2022-06-02T20:44:26Z",
+        "businessToken": "c1e98151-d230-48b3-b063-d8be437c1d60"
+      },
+      {
+        "token": "9dc20b01-1652-438f-bded-e1a2df240fef",
+        "status": "ACTIVE",
+        "reasonCode": "14",
+        "reason": "CardHolder creation",
+        "channel": "SYSTEM",
+        "createdTime": "2022-06-02T13:09:45Z",
+        "lastModifiedTime": "2022-06-02T13:09:45Z",
+        "businessToken": "c1e98151-d230-48b3-b063-d8be437c1d60"
+      }
+    ]
+  }
+}
+```
+
 ## Development
 
 For those interested in working on the library, there are a few things that

--- a/src/business-transition.ts
+++ b/src/business-transition.ts
@@ -64,7 +64,7 @@ export class BusinessTransitionApi {
    * Function to take a Transition token, send that to Marqeta, and have
    * the transition status information returned.
    */
-  async byTokenId(token: string): Promise<{
+  async retrieve(token: string): Promise<{
     success: boolean,
     transition?: Transition,
     error?: MarqetaError,

--- a/tests/business-transition.test.ts
+++ b/tests/business-transition.test.ts
@@ -9,14 +9,15 @@ import { Marqeta } from '../src';
     apiAccessToken: process.env.MARQETA_API_ACCESS_TOKEN
   })
 
+  let listItem, trans
   const businesses = await client.business.list()
 
-  let listItem
-  let trans
   if (businesses.businesses?.isMore) {
     listItem = businesses?.businesses?.data?.pop()
+
     if (listItem?.token) {
       console.log('transition Business status to Active...')
+
       if (listItem?.token && listItem?.status) {
         const state = {
           status: 'ACTIVE',
@@ -26,6 +27,9 @@ import { Marqeta } from '../src';
         }
         trans = await client.businessTransition.create(state)
       }
+
+      console.log(`${JSON.stringify(trans)}`)
+
       if (trans?.transition?.token) {
         console.log('Success! The Business was transitioned to status: "' +
           trans.transition.status + '"')
@@ -44,11 +48,14 @@ import { Marqeta } from '../src';
   }
 
   console.log('testing get Business transition by token Id...')
+
   if (trans?.transition?.token) {
     let getTrans
-    getTrans = await client.businessTransition.byTokenId(
+    getTrans = await client.businessTransition.retrieve(
       trans?.transition?.token
     )
+
+    console.log(`${JSON.stringify(getTrans)}`)
     if (getTrans?.transition?.token) {
       console.log('Success! We were able to get the Business ' +
         'transition status.')
@@ -64,9 +71,12 @@ import { Marqeta } from '../src';
   }
 
   console.log('testing list Business transitions by token Id...')
+
   if (listItem?.token) {
     let listTrans
     listTrans = await client.businessTransition.list({ ...listItem })
+
+    console.log(`${JSON.stringify(listTrans)}`)
     if (listTrans?.success && listTrans?.transitions?.count) {
       console.log('Success! We were able to get a list of Business ' +
         'transitions.')
@@ -82,9 +92,14 @@ import { Marqeta } from '../src';
   }
 
   console.log('testing list one Business transitions by token Id...')
+
   if (listItem?.token) {
     let listTrans
-    listTrans = await client.businessTransition.list({ ...listItem, count: 1 })
+    listTrans = await client.businessTransition.list({
+      ...listItem,
+      count: 1
+    })
+
     if (listTrans?.success && listTrans?.transitions?.count) {
       console.log('Success! We were able to get a list of one Business ' +
         'transitions.')


### PR DESCRIPTION
This pull request is for the `business-transition.ts` module `readme` documentation. This includes changing the name of the `byTokenId()` function to `retrieve()` to match the Marqeta API naming convention.  