### PR TITLE
marqeta-business-interface-fix

### DIFF
--- a/src/business.ts
+++ b/src/business.ts
@@ -60,7 +60,7 @@ export interface Business {
   beneficialOwner3?: BeneficialOwner;
   beneficialOwner4?: BeneficialOwner;
   attestorName?: string;
-  attestationConsent?: string;
+  attestationConsent?: boolean;
   attestationDate?: string;
   dateEstablished?: string;
 }


### PR DESCRIPTION
Pull request to fix the business.ts module business interface: the `attestationConsent` property is a `boolean`, not a `string`.