### PR TITLE
marqeta-transactions-test-fix

### DIFF
--- a/tests/transactions.test.ts
+++ b/tests/transactions.test.ts
@@ -68,7 +68,7 @@ import { Marqeta } from '../src'
           }
         )
         if (response?.payload?.transaction?.token) {
-          getTransaction = await client.transactions.byTokenId(
+          getTransaction = await client.transactions.retrieve(
             response.payload.transaction.token
           )
           if (getTransaction?.success && getTransaction?.transaction?.token) {


### PR DESCRIPTION
Small pull request to fix transactions.test.ts script as the `byTokenId()` was renamed to `retrieve()`. 